### PR TITLE
Alto Auto-fix: Pet counter is not working when clicking + in CodePath App/ViewController.swift

### DIFF
--- a/CodePath App/ViewController.swift
+++ b/CodePath App/ViewController.swift
@@ -1,3 +1,4 @@
+```swift
 //
 //  ViewController.swift
 //  CodePath App
@@ -18,7 +19,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var morePetsStepper: UIStepper!
     
     @IBAction func stepperDidChange(_ sender: UIStepper) {
-        numberOfPetsLabel.text = "\(Int(sender.value))"
+        numberOfPetsLabel.text = Int(sender.value).description
     }
     @IBAction func introduceSelfDidTapped(_ sender: UIButton) {
         let year = yearSegmentedControl.titleForSegment(at: yearSegmentedControl.selectedSegmentIndex)
@@ -31,8 +32,8 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+        numberOfPetsLabel.text = "0"
     }
 
 }
-
+```


### PR DESCRIPTION
Auto-generated fix for bug 'Pet counter is not working when clicking +' in CodePath App/ViewController.swift.

Bug Details:
Title: Pet counter is not working when clicking +
Type: frontend
Priority: medium
App: alto-test
