### PR TITLE
Alto Auto-fix: pet counter not incrementing when pressing + in CodePath App/ViewController.swift

### DIFF
--- a/CodePath App/ViewController.swift
+++ b/CodePath App/ViewController.swift
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var morePetsStepper: UIStepper!
     
     @IBAction func stepperDidChange(_ sender: UIStepper) {
-        numberOfPetsLabel.text = "\(Int(sender.value) * (-1))"
+        numberOfPetsLabel.text = "\(Int(sender.value))"
     }
     @IBAction func introduceSelfDidTapped(_ sender: UIButton) {
         let year = yearSegmentedControl.titleForSegment(at: yearSegmentedControl.selectedSegmentIndex)


### PR DESCRIPTION
Auto-generated fix for bug 'pet counter not incrementing when pressing +' in CodePath App/ViewController.swift.

Bug Details:
Title: pet counter not incrementing when pressing +
Type: frontend
Priority: medium
App: alto-test
